### PR TITLE
Basic API Exception Handling

### DIFF
--- a/src/main/java/com/restfiddle/controller/rest/ApiController.java
+++ b/src/main/java/com/restfiddle/controller/rest/ApiController.java
@@ -15,8 +15,10 @@
  */
 package com.restfiddle.controller.rest;
 
-import java.io.IOException;
-
+import com.restfiddle.dto.RfRequestDTO;
+import com.restfiddle.exceptions.ApiException;
+import com.restfiddle.handler.RequestHandler;
+import com.restfiddle.handler.http.GenericHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,12 +27,9 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.restfiddle.dto.RfRequestDTO;
-import com.restfiddle.handler.RequestHandler;
-import com.restfiddle.handler.http.GenericHandler;
+import java.io.IOException;
 
 @RestController
 @EnableAutoConfiguration
@@ -42,16 +41,14 @@ public class ApiController {
     @Autowired
     RequestHandler requestHandler;
 
-    @RequestMapping(value = "/api/processor", method = RequestMethod.POST, headers = "Accept=application/json")
-    String processor(@RequestBody RfRequestDTO rfRequestDTO) {
-        try {
-            GenericHandler handler = requestHandler.getHandler(rfRequestDTO.getMethodType());
-            return handler.process(rfRequestDTO.getApiUrl());
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return "Error!";
+    @RequestMapping(value = "/api/processor", method = RequestMethod.POST, headers = "Accept=application/json") String processor(
+		    @RequestBody RfRequestDTO rfRequestDTO) {
+	try {
+	    GenericHandler handler = requestHandler.getHandler(rfRequestDTO.getMethodType());
+	    return handler.process(rfRequestDTO.getApiUrl());
+	} catch (IOException e) {
+	    logger.error("IO Exception", e);
+	    throw new ApiException(e);
+	}
     }
-
 }

--- a/src/main/java/com/restfiddle/exceptions/ApiException.java
+++ b/src/main/java/com/restfiddle/exceptions/ApiException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 Santosh Mishra
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.restfiddle.exceptions;
+
+import java.io.IOException;
+
+/**
+ * Created by santoshm1 on 06/06/14.
+ */
+public class ApiException extends RuntimeException {
+
+    public ApiException(String message, Throwable cause) {
+	super(message, cause);
+    }
+
+    public ApiException(IOException e) {
+	super(e);
+    }
+
+}

--- a/src/main/java/com/restfiddle/exceptions/ApiExceptionControllerAdvice.java
+++ b/src/main/java/com/restfiddle/exceptions/ApiExceptionControllerAdvice.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 Santosh Mishra
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.restfiddle.exceptions;
+
+/**
+ * Created by santoshm1 on 06/06/14.
+ */
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class ApiExceptionControllerAdvice {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ResponseBody ErrorMessage handleException(ApiException ex) {
+	ErrorMessage errorMessage = new ErrorMessage(ex);
+	return errorMessage;
+    }
+
+}

--- a/src/main/java/com/restfiddle/exceptions/ErrorMessage.java
+++ b/src/main/java/com/restfiddle/exceptions/ErrorMessage.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 Santosh Mishra
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.restfiddle.exceptions;
+
+/**
+ * Created by santoshm1 on 06/06/14.
+ */
+public class ErrorMessage {
+
+    private String reason;
+
+    public ErrorMessage(String reason) {
+        this.reason = reason;
+    }
+
+    public ErrorMessage(ApiException ex) {
+       this.reason = ex.getMessage();
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+}


### PR DESCRIPTION
This will allow spring mvc to throw JSON errors in case of an API failure.

We should add some custom exceptions in ApiExceptionControllerAdvice. As a demonstration, I have thrown an ApiException from ApiController.
We ideally should have a handler for BusinessExceptions too, and an exception class for Business Exception - we'll build upon this when required.
Code formatting as per the formatter.
