### PR TITLE
UI Fixes part 5

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -432,6 +432,7 @@ ul .dropdown-menu li{
 	font-size: 12px;
 	border-radius: 3px;
 	color:#fff;
+	float: left;
 }
 
 .lozenge.green {
@@ -476,10 +477,6 @@ ul .dropdown-menu li{
 	font-size: 14px !important;
 	/*margin-top: 7px;*/
 	padding-left: 6px;
-}
-
-.date-time{
-	margin-left: 62px;
 }
 
 .username{
@@ -541,4 +538,8 @@ ul .dropdown-menu li{
   	margin-right: 1%;
   	margin-left: 1%;
   }
+}
+
+.activity{
+	overflow: hidden;
 }

--- a/src/main/resources/static/js/models/node.js
+++ b/src/main/resources/static/js/models/node.js
@@ -16,7 +16,8 @@ define(function(require) {
 			description : '',
 			parentId : '',
 			projectId: '',
-			nodeType : '',	
+			nodeType : '',
+			method : '',	
 			conversationDTO : ConversationModel,
             genericEntityDTO : EntityModel,
             tags : {}

--- a/src/main/resources/static/js/views/project-view.js
+++ b/src/main/resources/static/js/views/project-view.js
@@ -4,7 +4,7 @@ define(function(require) {
 	
 	var Backbone = require('backbone');
 	var _ = require('underscore');
-	
+	var APP = require('commons/ns');
 	var tree = require('views/tree-view');
 	var ProjectEvents = require('events/project-event');
 	
@@ -34,7 +34,8 @@ define(function(require) {
 			"click a" : "showProjectTree",
 			"click .hover-down-arrow" : "preventParentElmSelection",
             "click .edit-project" : "editProject",
-            "click .delete-project" : "deleteProject"
+            "click .delete-project" : "deleteProject",
+            "click .export-project" : "exportProject"
 		},
 		template : _.template($('#tpl-project-list-item').html()),
 		
@@ -70,7 +71,9 @@ define(function(require) {
             $("#deleteProjectId").val(this.model.get('id'));
             $("#deleteProjectModal").modal("show");
         },
-        
+        exportProject : function(){
+           window.open('http://localhost:8080/api/workspaces/'+ APP.appView.getCurrentWorkspaceId() +'/projects/'+ this.model.get('id'));
+        },        
 		showProjectTree : function(){
 			//this.$el.parent('ul').find('li').each(function(){
 				//$(this).removeClass('active');

--- a/src/main/resources/static/js/views/workspace-view.js
+++ b/src/main/resources/static/js/views/workspace-view.js
@@ -69,7 +69,8 @@ define(function(require) {
 		el : '#dd-workspace-wrapper',
 		template : _.template($('#tpl-workspace-list-item').html()),
 		events : {
-			"click .hover-down-arrow" : "preventParentElmSelection"
+			"click .hover-down-arrow" : "preventParentElmSelection",
+			"click .export-workspace" : "exportWorkspace"
 		},
         
 		render : function(eventName) {
@@ -92,6 +93,9 @@ define(function(require) {
 
 			}
 			
+		},
+		exportWorkspace : function(){
+			window.open('http://localhost:8080/api/workspaces/' + this.model.get('id'));
 		}
 	});
 	

--- a/src/main/webapp/WEB-INF/jsp/footer.jsp
+++ b/src/main/webapp/WEB-INF/jsp/footer.jsp
@@ -13,7 +13,7 @@
                     <li class="edit-project"><i class="fa fa-pencil fa-fw"></i> Edit Workspace</li>
                     <li class="delete-project"><i class="fa fa-trash-o fa-fw"></i> Delete Workspace</li>
                     <li class="divider"></li>
-                    <li class="edit-project"><i class="fa fa-download fa-fw"></i> Export Workspace</li>
+                    <li class="export-workspace"><i class="fa fa-download fa-fw"></i> Export Workspace</li>
                 </ul>
             </div></div>
 		</div>
@@ -30,7 +30,7 @@
                     <li class="edit-project"><i class="fa fa-pencil fa-fw"></i> Edit Project</li>
                     <li class="delete-project"><i class="fa fa-trash-o fa-fw"></i> Delete Project</li>
                     <li class="divider"></li>
-                    <li class="edit-project"><i class="fa fa-download fa-fw"></i> Export Project</li>
+                    <li class="export-project"><i class="fa fa-download fa-fw"></i> Export Project</li>
                 </ul>
             </div>
         </a>
@@ -78,8 +78,9 @@
 	</script>
 	<script type="text/template" id="tpl-history-list-item">
 		<a href="#" class="list-group-item" data-history-id=<@=conversation.id@> data-history-ref-id=<@=conversation.id@> >
-			<span class="<@=conversation.className@>"><@=conversation.rfRequest.methodType@></span><@=conversation.rfRequest.apiUrlString@><br>
-             <span class= "date-time"><@=conversation.time@></span>
+			<div class="<@=conversation.className@>"><@=conversation.rfRequest.methodType@></div>
+            <div class = "activity"><@=conversation.rfRequest.apiUrlString@></div>
+             <span><@=conversation.time@></span>
         </a>
 	</script>
     <script type="text/template" id="tpl-entity-field">


### PR DESCRIPTION
Completed Following points -
 2. 'Run Node' on Request (Tree node menu to be added after 'Copy Node') should populate request    fields in 3rd column, run it & show the response.
  4. a.Badges get lost if request name edited. Should be dynamic. #241
      b.When 1st column scrollbar appears, sometimes the space is left blank. #241 Occurs for 2nd &     3rd column as well.
6. a. Export Project should open project's JSON url in new tab. Browser's address bar should display the API url
   b. Export Workspace should open workspace JSON url in new tab. Browser's address bar should display the API url.
7. a. Activity log- when text is too huge.
8. b.Check request name non-emptiness when edited with pencil #242 


