### PR TITLE
multiple code improvements: squid:S1192, squid:S1854, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/com/restfiddle/controller/rest/WorkspaceController.java
+++ b/src/main/java/com/restfiddle/controller/rest/WorkspaceController.java
@@ -125,7 +125,7 @@ public class WorkspaceController {
 	List<Project> projects = workspace.getProjects();
 	
 	List<TreeNode> projectTreeList = new ArrayList<TreeNode>();
-	TreeNode projectTree = null;
+	TreeNode projectTree;
 	for (Project project : projects) {
 	    projectTree = nodeController.getProjectTree(project.getProjectRef().getId());
 	    projectTreeList.add(projectTree);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1854 - Dead stores should be removed.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava