### PR TITLE
multiple code improvements: squid:S1854, squid:S1155, squid:S1192, squid:S00115, squid:S1068, squid:S1118

### DIFF
--- a/src/main/java/com/restfiddle/controller/rest/GenericEntityController.java
+++ b/src/main/java/com/restfiddle/controller/rest/GenericEntityController.java
@@ -65,7 +65,7 @@ public class GenericEntityController {
 	List<GenericEntityFieldDTO> fieldDTOs = genericEntityDTO.getFields();
 	if (fieldDTOs != null && !fieldDTOs.isEmpty()) {
 	    List<GenericEntityField> fields = new ArrayList<GenericEntityField>();
-	    GenericEntityField field = null;
+	    GenericEntityField field;
 	    for (GenericEntityFieldDTO fieldDTO : fieldDTOs) {
 		field = new GenericEntityField();
 		field.setName(fieldDTO.getName());

--- a/src/main/java/com/restfiddle/controller/rest/NodeController.java
+++ b/src/main/java/com/restfiddle/controller/rest/NodeController.java
@@ -64,6 +64,8 @@ import com.restfiddle.util.TreeNode;
 @ComponentScan
 @Transactional
 public class NodeController {
+    private static final String PROJECT = "PROJECT";
+
     Logger logger = LoggerFactory.getLogger(NodeController.class);
 
     @Autowired
@@ -306,8 +308,8 @@ public class NodeController {
 	Map<String, BaseNode> baseNodeMap = new HashMap<String, BaseNode>();
 	Map<String, TreeNode> treeNodeMap = new HashMap<String, TreeNode>();
 	TreeNode rootNode = null;
-	TreeNode treeNode = null;
-	TreeNode parentTreeNode = null;
+	TreeNode treeNode;
+	TreeNode parentTreeNode;
 	String methodType = "";
 
 	for (BaseNode baseNode : listOfNodes) {
@@ -374,7 +376,7 @@ public class NodeController {
     private void sortTree(TreeNode rootNode, String sort, final int order) {
 	if (rootNode != null && rootNode.getChildren() != null) {
 
-	    Comparator<TreeNode> comparator = null;
+	    Comparator<TreeNode> comparator;
 
 	    switch (sort) {
 	    case "lastModified":
@@ -432,7 +434,7 @@ public class NodeController {
 
 	    Collections.sort(childs, comparator);
 
-	    if (childs.size() > 0) {
+	    if (!childs.isEmpty()) {
 		rootNode.setLastModifiedDate(childs.get(0).getLastModifiedDate());
 	    }
 	}
@@ -540,16 +542,16 @@ public class NodeController {
 	}
 
 	// Not allowed to save request under a request
-	if (position.equals("over") && !(newRefNode.getNodeType().equalsIgnoreCase("PROJECT") || newRefNode.getNodeType().equalsIgnoreCase("FOLDER"))) {
+	if (position.equals("over") && !(newRefNode.getNodeType().equalsIgnoreCase(PROJECT) || newRefNode.getNodeType().equalsIgnoreCase("FOLDER"))) {
 	    return;
 	}
 	// Special case where -1 getting saved for non-project node
-	if (!(node.getNodeType() != null && node.getNodeType().equalsIgnoreCase("PROJECT")) && newParentId.equals("-1")){
+	if (!(node.getNodeType() != null && node.getNodeType().equalsIgnoreCase(PROJECT)) && newParentId.equals("-1")){
 	    return;
 	}
 	// update new folder
 	List<BaseNode> newFolderChildren;
-	if(newRefNode.getNodeType() != null && (newRefNode.getNodeType().equalsIgnoreCase("PROJECT") || newRefNode.getNodeType().equalsIgnoreCase("FOLDER"))){
+	if(newRefNode.getNodeType() != null && (newRefNode.getNodeType().equalsIgnoreCase(PROJECT) || newRefNode.getNodeType().equalsIgnoreCase("FOLDER"))){
 	    newFolderChildren = nodeRepository.getChildren(newRefNode.getId());
 	}else{
 	    newFolderChildren = nodeRepository.getChildren(newRefNode.getParentId());

--- a/src/main/java/com/restfiddle/controller/rest/ProjectController.java
+++ b/src/main/java/com/restfiddle/controller/rest/ProjectController.java
@@ -85,7 +85,7 @@ public class ProjectController {
 
 	// Update projectRef (Set projectId to the reference node)
 	projectRef.setProjectId(savedProject.getId());
-	savedRef = nodeRepository.save(projectRef);
+	nodeRepository.save(projectRef);
 
 	// Update workspace
 	Workspace workspace = workspaceRepository.findOne(workspaceId);

--- a/src/main/java/com/restfiddle/controller/rest/sample/SampleWebController.java
+++ b/src/main/java/com/restfiddle/controller/rest/sample/SampleWebController.java
@@ -36,8 +36,7 @@ public class SampleWebController {
     @Value("${application.message:REST Fiddle}")
     private String message = "REST Fiddle";
 
-    private static final String template = "Hello, %s!";
-    private final AtomicLong counter = new AtomicLong();
+    private static final String TEMPLATE = "Hello, %s!";
 
     @RequestMapping("/web")
     public String home(Map<String, Object> model) {
@@ -50,7 +49,7 @@ public class SampleWebController {
     public @ResponseBody
     User sayHello(@RequestParam(value = "name", required = false, defaultValue = "JSON") String name) {
 	User user = new User();
-	user.setName(String.format(template, name));
+	user.setName(String.format(TEMPLATE, name));
 	return user;
     }
 }

--- a/src/main/java/com/restfiddle/controller/util/NodeUtil.java
+++ b/src/main/java/com/restfiddle/controller/util/NodeUtil.java
@@ -21,8 +21,10 @@ import com.restfiddle.entity.BaseNode;
 
 public class NodeUtil {
 
+    private NodeUtil() {}
+
     public static long findLastChildPosition(List<BaseNode> children) {
-	if (children == null || children.size() == 0) {
+	if (children == null || children.isEmpty()) {
 	    return 0;
 	}
 	long temp = 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1192 - String literals should not be duplicated.
squid:S00115 - Constant names should comply with a naming convention.
squid:S1068 - Unused private fields should be removed.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava