### PR TITLE
squid:S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/restfiddle/util/CommonUtil.java
+++ b/src/main/java/com/restfiddle/util/CommonUtil.java
@@ -8,6 +8,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class CommonUtil {
 
+    private CommonUtil() {}
+
     /**
      * @param object
      * @return

--- a/src/main/java/com/restfiddle/util/EntityToDTO.java
+++ b/src/main/java/com/restfiddle/util/EntityToDTO.java
@@ -49,6 +49,8 @@ import com.restfiddle.entity.Workspace;
 
 public class EntityToDTO {
 
+    private EntityToDTO() {}
+
     public static BaseDTO toDTO(BaseEntity entity) {
 	if (entity == null)
 	    return null;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava