### PR TITLE
squid:S1118: Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/restfiddle/RestFiddleApplication.java
+++ b/src/main/java/com/restfiddle/RestFiddleApplication.java
@@ -25,6 +25,8 @@ import org.springframework.context.annotation.Configuration;
 @ComponentScan
 public class RestFiddleApplication {
 
+    private RestFiddleApplication() {}
+
     public static void main(String[] args) throws Exception {
 	SpringApplication.run(RestFiddleApplication.class, args);
     }

--- a/src/main/java/com/restfiddle/config/PropertyConfig.java
+++ b/src/main/java/com/restfiddle/config/PropertyConfig.java
@@ -16,8 +16,11 @@ import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 @Configuration
 @PropertySource({ "classpath:common.properties" })
 public class PropertyConfig {
-    static @Bean
-    public PropertySourcesPlaceholderConfigurer myPropertySourcesPlaceholderConfigurer() {
+
+    private PropertyConfig() {} 
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer myPropertySourcesPlaceholderConfigurer() {
 	return new PropertySourcesPlaceholderConfigurer();
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava