### PR TITLE
multiple code improvements: squid:S2259, squid:S1862, squid:S1858

### DIFF
--- a/src/main/java/com/restfiddle/controller/rest/ApiController.java
+++ b/src/main/java/com/restfiddle/controller/rest/ApiController.java
@@ -126,9 +126,11 @@ public class ApiController {
 	    existingConversation = conversationId != null ? conversationRepository.findOne(conversationId) : null;
 	    // finding updated existing conversation
 	    existingConversation = existingConversation != null ? nodeRepository.findOne(existingConversation.getNodeId()).getConversation() : null;
-	    rfRequestDTO.setAssertionDTO(EntityToDTO.toDTO(existingConversation.getRfRequest().getAssertion()));
+	    if(existingConversation != null) {
+	       rfRequestDTO.setAssertionDTO(EntityToDTO.toDTO(existingConversation.getRfRequest().getAssertion()));
+	    }
 	}
-
+	
 	long startTime = System.currentTimeMillis();
 	RfResponseDTO result = genericHandler.processHttpRequest(rfRequestDTO);
 	long endTime = System.currentTimeMillis();
@@ -191,9 +193,11 @@ public class ApiController {
 	    conversationRepository.save(currentConversation);
 	    
 	    if (activityLog == null) {
-	    activityLog = new ActivityLog();
-	    	activityLog.setDataId(existingConversation.getNodeId());
-	    	activityLog.setType("CONVERSATION");
+	        activityLog = new ActivityLog();
+	        if(existingConversation != null) {
+	           activityLog.setDataId(existingConversation.getNodeId());
+	        }
+	        activityLog.setType("CONVERSATION");
 	    }
 	    
 	    activityLog.setName(currentConversation.getName());

--- a/src/main/java/com/restfiddle/controller/rest/GenerateApiController.java
+++ b/src/main/java/com/restfiddle/controller/rest/GenerateApiController.java
@@ -230,8 +230,6 @@ public class GenerateApiController {
 		jsonObject.put(genericEntityField.getName(), false);
 	    } else if ("DATE".equalsIgnoreCase(type)) {
 		jsonObject.put(genericEntityField.getName(), new Date());
-	    } else if ("NUMBER".equalsIgnoreCase(type)) {
-		jsonObject.put(genericEntityField.getName(), Long.valueOf(1));
 	    } else if ("OBJECT".equalsIgnoreCase(type)) {
 		jsonObject.put(genericEntityField.getName(), new JSONObject());
 	    } else if ("ARRAY".equalsIgnoreCase(type)) {

--- a/src/main/java/com/restfiddle/dao/util/ConversationConverter.java
+++ b/src/main/java/com/restfiddle/dao/util/ConversationConverter.java
@@ -124,7 +124,7 @@ public class ConversationConverter {
 		response.setAssertion(assertion);
 	    }
 	    
-	    List<RfHeaderDTO> headerDTOs = responseDTO.getHeaders();
+	    List<RfHeaderDTO> headerDTOs = responseDTO != null ? responseDTO.getHeaders() : null;
 	    List<RfHeader> headers = new ArrayList<RfHeader>();
 	    RfHeader header;
 	    if (headerDTOs != null && !headerDTOs.isEmpty()) {

--- a/src/main/java/com/restfiddle/entity/User.java
+++ b/src/main/java/com/restfiddle/entity/User.java
@@ -72,22 +72,22 @@ public class User extends NamedEntity implements UserDetails {
 
     @Override
     public boolean isAccountNonExpired() {
-	return StatusType.ACTIVE.toString().equals(super.getStatus().toString());
+	return StatusType.ACTIVE.toString().equals(super.getStatus());
     }
 
     @Override
     public boolean isAccountNonLocked() {
-	return StatusType.ACTIVE.toString().equals(super.getStatus().toString());
+	return StatusType.ACTIVE.toString().equals(super.getStatus());
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-	return StatusType.ACTIVE.toString().equals(super.getStatus().toString());
+	return StatusType.ACTIVE.toString().equals(super.getStatus());
     }
 
     @Override
     public boolean isEnabled() {
-	return StatusType.ACTIVE.toString().equals(super.getStatus().toString());
+	return StatusType.ACTIVE.toString().equals(super.getStatus());
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2259 - Null pointers should not be dereferenced.
squid:S1862 - Conditions in related "if/else if" statements should not have the same condition.
squid:S1858 - "toString()" should never be called on a String object.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2259
https://dev.eclipse.org/sonar/rules/show/squid:S1862
https://dev.eclipse.org/sonar/rules/show/squid:S1858
Please let me know if you have any questions.
George Kankava