### PR TITLE
multiple code improvements: squid:SwitchLastCaseIsDefaultCheck, squid:S1301, squid:S1854, squid:S1192, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/com/restfiddle/handler/AssertHandler.java
+++ b/src/main/java/com/restfiddle/handler/AssertHandler.java
@@ -102,6 +102,8 @@ public class AssertHandler {
 	    case "! Contains":
 		result = !actualValue.contains(expectedValue);
 		break;
+		default:
+			break;
 	    }
 
 	    return result;
@@ -132,6 +134,8 @@ public class AssertHandler {
 	    case ">=":
 		result = actual >= expected;
 		break;
+		default:
+			break;
 	    }
 
 	    return result;
@@ -154,6 +158,8 @@ public class AssertHandler {
 	    case "! Contains Value":
 		result = !actualValue.containsValue(expectedValue);
 		break;
+		default:
+			break;
 
 	    }
 
@@ -162,15 +168,10 @@ public class AssertHandler {
 
 	private boolean evaluate(String expectedValue, String comparator, List<Object> actualValue) {
 	    boolean result = false;
-
-	    switch (comparator) {
-	    case "Contains Value":
-		result = actualValue.contains(expectedValue);
-		break;
-	    case "! Contains Value":
-		result = !actualValue.contains(expectedValue);
-		break;
-
+	    if(comparator.equals("Contains Value")) {
+	        result = actualValue.contains(expectedValue);
+	    } else if(comparator.equals("! Contains Value")) {
+	        result = !actualValue.contains(expectedValue);
 	    }
 	    return result;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck -"switch" statements should end with a "default" clause.
squid:S1301 - "switch" statements should have at least 3 "case" clauses.
squid:S1854 - Dead stores should be removed.
squid:S1192 - String literals should not be duplicated.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1301
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava